### PR TITLE
Adding poetry-plugin-shell installation command into README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ This project offers flexible setup options to accommodate different user environ
     $ cd AIOpsLab
     $ pip install poetry
     $ poetry install -vvv
+    $ poetry self add poetry-plugin-shell
     $ poetry shell
     ```
 


### PR DESCRIPTION
*This PR updates the README to reflect the change in Poetry where the `poetry shell` command has been moved to the `poetry-plugin-shell` plugin.*

fixes #12 