### PR TITLE
feat: fix api fetch error for docker client

### DIFF
--- a/aiopslab/service/dock.py
+++ b/aiopslab/service/dock.py
@@ -5,11 +5,32 @@
 
 import docker
 import subprocess
+import os
+import json
 
 
 class Docker:
-    def __init__(self):
-        self.client = docker.from_env()
+    def __init__(self, base_url: str | None = None):
+        self.client = None
+
+        try:
+            env_client = docker.from_env()
+            env_client.ping()
+            self.client = env_client
+            return
+        except Exception:
+            print("Failed to connect to docker client from docker env")
+            pass
+
+        context_host = _docker_context_host()
+        try:
+            if context_host:
+                env_client = docker.DockerClient(base_url=context_host)
+                env_client.ping()
+                self.client = env_client
+                return
+        except Exception as e:
+            print(f"Failed to connect to docker client from {context_host}: {e}")
 
     def list_containers(self):
         """Get all containers."""
@@ -55,3 +76,40 @@ class Docker:
                 return out.stdout.decode("utf-8")
         except subprocess.CalledProcessError as e:
             return e.stderr.decode("utf-8")
+
+
+def _docker_context_host() -> str | None:
+    try:
+        ctx = subprocess.run(
+            ["docker", "context", "show"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            check=False,
+        ).stdout.strip()
+        if not ctx:
+            return None
+        out = subprocess.run(
+            [
+                "docker",
+                "context",
+                "inspect",
+                ctx,
+                "--format",
+                "{{json .Endpoints.docker.Host}}",
+            ],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            check=False,
+        ).stdout.strip()
+        if not out:
+            return None
+        # Output is a JSON string like "unix:///Users/.../.docker/run/docker.sock"
+        try:
+            host = json.loads(out)
+            return host
+        except json.JSONDecodeError:
+            return out.strip('"')
+    except Exception:
+        return None


### PR DESCRIPTION
## What
The Docker client cannot connect because it failed to fetch the Docker daemon for problem ID `k8s_target_port-misconfig-detection-1`.
<img width="1402" height="229" alt="image" src="https://github.com/user-attachments/assets/0658a1e3-c868-4606-aa93-6ffc437cb20c" />

### Env
- MacOS 15.6.1 (24G90), ARM architecture
- Python 3.11

## How
- Add fallback logic to Docker client initialization using the current Docker context when the environment-based connection fails
- Add `_docker_context_host` method to inspect and parse Docker context endpoints
