### PR TITLE
fix fault injection for paymentFailure and imageSlowLoad in Otel

### DIFF
--- a/aiopslab/generators/fault/inject_otel.py
+++ b/aiopslab/generators/fault/inject_otel.py
@@ -29,7 +29,12 @@ class OtelFaultInjector(FaultInjector):
         flagd_data = json.loads(configmap["data"]["demo.flagd.json"])
 
         if feature_flag in flagd_data["flags"]:
-            flagd_data["flags"][feature_flag]["defaultVariant"] = "on"
+            if feature_flag == "paymentFailure":
+                flagd_data["flags"][feature_flag]["defaultVariant"] = "100%"
+            elif feature_flag == "imageSlowLoad":
+                flagd_data["flags"][feature_flag]["defaultVariant"] = "10sec"
+            else:
+                flagd_data["flags"][feature_flag]["defaultVariant"] = "on"
         else:
             raise ValueError(
                 f"Feature flag '{feature_flag}' not found in ConfigMap '{self.configmap_name}'."


### PR DESCRIPTION
The feature flag for injecting paymentFailure and imageSlowLoad is not "on".

https://github.com/xlab-uiuc/opentelemetry-helm-charts/blob/68d88623f480687a0a50dcd7ca1ff3340bb1ff7a/charts/opentelemetry-demo/flagd/demo.flagd.json#L67-L80

```
    "paymentFailure": {
      "description": "Fail payment service charge requests n%",
      "state": "ENABLED",
      "variants": {
        "100%": 1,
        "90%": 0.95,
        "75%": 0.75,
        "50%": 0.5,
        "25%": 0.25,
        "10%": 0.1,
        "off": 0
      },
      "defaultVariant": "off"
    },
    "imageSlowLoad": {
      "description": "slow loading images in the frontend",
      "state": "ENABLED",
      "variants": {
        "10sec": 10000,
        "5sec": 5000,
        "off": 0
      },
      "defaultVariant": "off"
    }
```