### PR TITLE
fix: handle None return from get_container_runtime()

### DIFF
--- a/aiopslab/generators/fault/inject_symp.py
+++ b/aiopslab/generators/fault/inject_symp.py
@@ -28,6 +28,12 @@ class SymptomFaultInjector(FaultInjector):
 
         container_runtime = self.kubectl.get_container_runtime()
 
+        if container_runtime is None:
+            raise ValueError(
+                "Could not detect container runtime. "
+                "Ensure the cluster is running and at least one node is Ready."
+            )
+
         if "docker" in container_runtime:
             pass
         elif "containerd" in container_runtime:

--- a/aiopslab/service/kubectl.py
+++ b/aiopslab/service/kubectl.py
@@ -54,15 +54,27 @@ class KubeCtl:
         service_info = self.core_v1_api.read_namespaced_service(service_name, namespace)
         return service_info.spec.cluster_ip  # type: ignore
     
-    def get_container_runtime(self):
+    def get_container_runtime(self, max_wait: int = 60, poll_interval: int = 2):
         """
             Retrieve the container runtime used by the cluster.
             If the cluster uses multiple container runtimes, the first one found will be returned.
+            
+            Args:
+                max_wait: Maximum seconds to wait for a Ready node (default: 60)
+                poll_interval: Seconds between checks (default: 2)
+            
+            Returns:
+                Container runtime version string, or None if no Ready node found within max_wait.
         """
-        for node in self.core_v1_api.list_node().items:
-            for status in node.status.conditions:
-                if status.type == "Ready" and status.status == "True":
-                    return node.status.node_info.container_runtime_version
+        elapsed = 0
+        while elapsed < max_wait:
+            for node in self.core_v1_api.list_node().items:
+                for status in node.status.conditions:
+                    if status.type == "Ready" and status.status == "True":
+                        return node.status.node_info.container_runtime_version
+            time.sleep(poll_interval)
+            elapsed += poll_interval
+        return None
 
     def get_pod_name(self, namespace, label_selector):
         """Get the name of the first pod in a namespace that matches a given label selector."""


### PR DESCRIPTION
## Description
Fixes a TypeError crash that occurred when running network_delay and other chaos mesh injection tasks immediately after cluster creation.

## Problem
The `get_container_runtime()` method was returning `None` when called before any Kubernetes nodes reached "Ready" state. This caused:
```
TypeError: argument of type 'NoneType' is not iterable
```
at line 30 in `inject_symp.py` when checking `if 'docker' in container_runtime`.

## Solution
1. **Added retry logic** to `get_container_runtime()`: Waits up to 60 seconds (configurable) for at least one node to become Ready
2. **Added explicit None check** in `SymptomFaultInjector.__init__()`: Provides clear error message if container runtime cannot be detected

## Testing
- Verified the fix by running `network_delay_hotel_res-detection-1` task
- Task now successfully proceeds past initialization instead of crashing

## Affected Tasks
All chaos mesh-based fault injection tasks including:
- network_delay
- pod_failure
- pod_kill
- network_loss
- container_kill

## Checklist
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Tested locally
- [x] Code follows project style guidelines