### PR TITLE
exec_shell: honor optional timeout argument end-to-end

### DIFF
--- a/aiopslab/orchestrator/actions/base.py
+++ b/aiopslab/orchestrator/actions/base.py
@@ -101,7 +101,7 @@ class TaskActions:
             if pattern in command:
                 return error
 
-        result = Shell.exec(command) 
+        result = Shell.exec(command, timeout=timeout) 
 
         if re.search(LOG_COMMAND_PATTERN, command):
             result = greedy_compress_lines(result)

--- a/aiopslab/orchestrator/parser.py
+++ b/aiopslab/orchestrator/parser.py
@@ -130,6 +130,25 @@ exec_shell("kubectl get services --all-namespaces")
                 if args_str.startswith("command="):
                     args_str = args_str.replace("command=", "").strip()
 
+                # optional trailing timeout: exec_shell("...", 90) or
+                # exec_shell("...", timeout=90). The command itself is a quoted
+                # string that may contain commas, so only split off a trailing
+                # integer when the remaining argument is still a complete quoted
+                # string -- this avoids mis-parsing a "..., 90" inside a command.
+                kwargs: dict = {}
+                timeout_match = re.search(
+                    r"^(?P<cmd>.+?)\s*,\s*(?:timeout\s*=\s*)?(?P<to>\d+)\s*$",
+                    args_str,
+                    re.DOTALL,
+                )
+                if timeout_match:
+                    candidate = timeout_match.group("cmd").strip()
+                    if (candidate.startswith('"') and candidate.endswith('"')) or (
+                        candidate.startswith("'") and candidate.endswith("'")
+                    ):
+                        args_str = candidate
+                        kwargs = {"timeout": int(timeout_match.group("to"))}
+
                 if args_str.startswith('"') and args_str.endswith('"'):
                     arg_str = args_str.strip('"')
                 elif args_str.startswith("'") and args_str.endswith("'"):
@@ -140,7 +159,7 @@ exec_shell("kubectl get services --all-namespaces")
                     )
 
                 arg_str = arg_str.replace('\\"', '"').replace("\\'", "'")
-                return [arg_str], {}
+                return [arg_str], kwargs
 
             # case: positional/kwargs handled w/ ast.parse
             try:

--- a/tests/parser/test_shell_timeout.py
+++ b/tests/parser/test_shell_timeout.py
@@ -1,0 +1,48 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Tests that exec_shell honors an optional timeout argument."""
+
+import unittest
+
+from aiopslab.orchestrator.parser import ResponseParser
+
+
+def _block(call: str) -> str:
+    return f"Action:\n```\n{call}\n```"
+
+
+class TestShellTimeout(unittest.TestCase):
+    def setUp(self):
+        self.parser = ResponseParser()
+
+    def test_shell_without_timeout(self):
+        resp = self.parser.parse(_block('exec_shell("kubectl get pods")'))
+        self.assertEqual(resp["args"], ["kubectl get pods"])
+        self.assertEqual(resp["kwargs"], {})
+
+    def test_shell_positional_timeout(self):
+        resp = self.parser.parse(_block('exec_shell("kubectl rollout status deploy/x", 90)'))
+        self.assertEqual(resp["args"], ["kubectl rollout status deploy/x"])
+        self.assertEqual(resp["kwargs"], {"timeout": 90})
+
+    def test_shell_keyword_timeout(self):
+        resp = self.parser.parse(_block('exec_shell("sleep 5", timeout=120)'))
+        self.assertEqual(resp["args"], ["sleep 5"])
+        self.assertEqual(resp["kwargs"], {"timeout": 120})
+
+    def test_trailing_number_inside_command_is_not_a_timeout(self):
+        # The command itself ends in ", 90"; without a closing quote after it,
+        # it must stay part of the command, not be parsed as a timeout.
+        resp = self.parser.parse(_block('exec_shell("echo a, 90")'))
+        self.assertEqual(resp["args"], ["echo a, 90"])
+        self.assertEqual(resp["kwargs"], {})
+
+    def test_single_quoted_command_still_parses(self):
+        resp = self.parser.parse(_block("exec_shell('echo hello', 30)"))
+        self.assertEqual(resp["args"], ["echo hello"])
+        self.assertEqual(resp["kwargs"], {"timeout": 30})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/shell/test_exec_shell_timeout_forwarding.py
+++ b/tests/shell/test_exec_shell_timeout_forwarding.py
@@ -1,0 +1,39 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Tests that TaskActions.exec_shell forwards its timeout to Shell.exec."""
+
+import unittest
+from unittest.mock import patch
+
+from aiopslab.orchestrator.actions.base import TaskActions
+
+
+class TestExecShellTimeoutForwarding(unittest.TestCase):
+    def test_default_timeout_is_forwarded(self):
+        with patch(
+            "aiopslab.orchestrator.actions.base.Shell.exec", return_value="ok"
+        ) as mock_exec:
+            TaskActions.exec_shell("echo hi")
+        mock_exec.assert_called_once_with("echo hi", timeout=30)
+
+    def test_custom_timeout_is_forwarded(self):
+        with patch(
+            "aiopslab.orchestrator.actions.base.Shell.exec", return_value="ok"
+        ) as mock_exec:
+            TaskActions.exec_shell("kubectl rollout status deploy/x", timeout=90)
+        mock_exec.assert_called_once_with(
+            "kubectl rollout status deploy/x", timeout=90
+        )
+
+    def test_blocked_command_does_not_reach_shell(self):
+        with patch(
+            "aiopslab.orchestrator.actions.base.Shell.exec", return_value="ok"
+        ) as mock_exec:
+            out = TaskActions.exec_shell("kubectl edit svc/foo", timeout=90)
+        mock_exec.assert_not_called()
+        self.assertIn("kubectl patch", out)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

`exec_shell` advertises a tunable `timeout` (`def exec_shell(command, timeout=30)`), but it never took effect. This PR makes the timeout work end-to-end so agents can run legitimately long commands (e.g. `kubectl rollout status ... --timeout=90s`) instead of being silently capped at 30s.

## Problem

The `timeout` was dropped in two places:

1. **Parser** — the shell-command branch of `ResponseParser` returned `[arg_str], {}`, discarding any timeout the agent passed.
2. **Action** — even if it had arrived, `exec_shell` called `Shell.exec(command)` without forwarding `timeout`, so it always fell back to the 30s default.

Net effect: `exec_shell("kubectl rollout status ...", 90)` was killed at 30s regardless of what the agent requested.

## Changes

- `aiopslab/orchestrator/parser.py`: parse an optional trailing timeout — `exec_shell("...", 90)` or `exec_shell("...", timeout=90)` — and return it as `kwargs={"timeout": N}`. The split only triggers when the remaining argument is still a complete quoted string, so a literal `", 90"` *inside* a command is not mis-parsed as a timeout.
- `aiopslab/orchestrator/actions/base.py`: forward the value — `Shell.exec(command, timeout=timeout)`.

`Shell.exec`/`local_exec`/`ssh_exec`/`docker_exec` already accept and honor `timeout`, so no change is needed there.

## Backward compatibility

Fully backward compatible. Commands with no timeout argument parse exactly as before and default to 30s.

## Testing

- `tests/parser/test_shell_timeout.py` — no-timeout, positional, keyword, single-quoted, and the "trailing number inside a command is not a timeout" edge case.
- `tests/shell/test_exec_shell_timeout_forwarding.py` — asserts `exec_shell` forwards the timeout (default and custom) to `Shell.exec`, and that blocked commands never reach the shell.

Both suites pass.
