### PR TITLE
Add a bounded settle window to mitigation recovery eval

### DIFF
--- a/aiopslab/orchestrator/problems/assign_non_existent_node/assign_non_existent_node_social_net.py
+++ b/aiopslab/orchestrator/problems/assign_non_existent_node/assign_non_existent_node_social_net.py
@@ -194,32 +194,9 @@ class AssignNonExistentNodeSocialNetMitigation(
             print(f"Pod named {self.faulty_service} does not exist.")
             all_normal = False
         else:
-            for pod in pod_list.items:
-                if pod.status.container_statuses:
-                    for container_status in pod.status.container_statuses:
-                        if (
-                            container_status.state.waiting
-                            and container_status.state.waiting.reason
-                            == "CrashLoopBackOff"
-                        ):
-                            print(
-                                f"Container {container_status.name} is in CrashLoopBackOff"
-                            )
-                            all_normal = False
-                        elif (
-                            container_status.state.terminated
-                            and container_status.state.terminated.reason != "Completed"
-                        ):
-                            print(
-                                f"Container {container_status.name} is terminated with reason: {container_status.state.terminated.reason}"
-                            )
-                            all_normal = False
-                        elif not container_status.ready:
-                            print(f"Container {container_status.name} is not ready")
-                            all_normal = False
-
-                if not all_normal:
-                    break
+            # Faulty pod is rescheduled; allow dependent workloads time to
+            # recover before judging (see MitigationTask.wait_until_pods_healthy).
+            all_normal = self.wait_until_pods_healthy(self.namespace)
 
         self.results["success"] = all_normal
         return self.results

--- a/aiopslab/orchestrator/problems/auth_miss_mongodb/auth_miss_mongodb.py
+++ b/aiopslab/orchestrator/problems/auth_miss_mongodb/auth_miss_mongodb.py
@@ -176,33 +176,10 @@ class MongoDBAuthMissingMitigation(MongoDBAuthMissingBaseTask, MitigationTask):
         print("== Evaluation ==")
         super().eval(soln, trace, duration)
 
-        # Check if all services (not only faulty service) is back to normal (Running)
-        pod_list = self.kubectl.list_pods(self.namespace)
-        all_normal = True
-
-        for pod in pod_list.items:
-            # Check container statuses
-            for container_status in pod.status.container_statuses:
-                if (
-                    container_status.state.waiting
-                    and container_status.state.waiting.reason == "CrashLoopBackOff"
-                ):
-                    print(f"Container {container_status.name} is in CrashLoopBackOff")
-                    all_normal = False
-                elif (
-                    container_status.state.terminated
-                    and container_status.state.terminated.reason != "Completed"
-                ):
-                    print(
-                        f"Container {container_status.name} is terminated with reason: {container_status.state.terminated.reason}"
-                    )
-                    all_normal = False
-                elif not container_status.ready:
-                    print(f"Container {container_status.name} is not ready")
-                    all_normal = False
-
-            if not all_normal:
-                break
-
-        self.results["success"] = all_normal
+        # Allow dependent workloads time to recover before judging. A correct
+        # fix for an app-level fault (e.g. MongoDB auth) often leaves dependent
+        # pods briefly in CrashLoopBackOff, so poll for recovery instead of
+        # taking a single snapshot at submit() time (see
+        # MitigationTask.wait_until_pods_healthy).
+        self.results["success"] = self.wait_until_pods_healthy(self.namespace)
         return self.results

--- a/aiopslab/orchestrator/problems/k8s_target_port_misconfig/target_port.py
+++ b/aiopslab/orchestrator/problems/k8s_target_port_misconfig/target_port.py
@@ -176,35 +176,9 @@ class K8STargetPortMisconfigMitigation(K8STargetPortMisconfigBaseTask, Mitigatio
         all_normal = is_exact_match(target_port, 9090)
 
         if all_normal:
-            # Check if all services (not only faulty service) is back to normal (Running)
-            pod_list = self.kubectl.list_pods(self.namespace)
-            for pod in pod_list.items:
-                if pod.status.container_statuses:
-                    # Check container statuses
-                    for container_status in pod.status.container_statuses:
-                        if (
-                            container_status.state.waiting
-                            and container_status.state.waiting.reason
-                            == "CrashLoopBackOff"
-                        ):
-                            print(
-                                f"Container {container_status.name} is in CrashLoopBackOff"
-                            )
-                            all_normal = False
-                        elif (
-                            container_status.state.terminated
-                            and container_status.state.terminated.reason != "Completed"
-                        ):
-                            print(
-                                f"Container {container_status.name} is terminated with reason: {container_status.state.terminated.reason}"
-                            )
-                            all_normal = False
-                        elif not container_status.ready:
-                            print(f"Container {container_status.name} is not ready")
-                            all_normal = False
-
-                if not all_normal:
-                    break
+            # targetPort is correct; now allow dependent workloads time to
+            # recover before judging (see MitigationTask.wait_until_pods_healthy).
+            all_normal = self.wait_until_pods_healthy(self.namespace)
 
         self.results["success"] = all_normal
         return self.results

--- a/aiopslab/orchestrator/problems/kafka_queue_problems/kafka_queue_problems.py
+++ b/aiopslab/orchestrator/problems/kafka_queue_problems/kafka_queue_problems.py
@@ -107,36 +107,8 @@ class KafkaQueueProblemsMitigation(KafkaQueueProblemsBaseTask, MitigationTask):
         print("== Evaluation ==")
         super().eval(soln, trace, duration)
 
-        # Check if all services (not only faulty service) is back to normal (Running)
-        pod_list = self.kubectl.list_pods(self.namespace)
-        all_normal = True
-
-        for pod in pod_list.items:
-            if pod.status.container_statuses:
-                # Check container statuses
-                for container_status in pod.status.container_statuses:
-                    if (
-                        container_status.state.waiting
-                        and container_status.state.waiting.reason == "CrashLoopBackOff"
-                    ):
-                        print(
-                            f"Container {container_status.name} is in CrashLoopBackOff"
-                        )
-                        all_normal = False
-                    elif (
-                        container_status.state.terminated
-                        and container_status.state.terminated.reason != "Completed"
-                    ):
-                        print(
-                            f"Container {container_status.name} is terminated with reason: {container_status.state.terminated.reason}"
-                        )
-                        all_normal = False
-                    elif not container_status.ready:
-                        print(f"Container {container_status.name} is not ready")
-                        all_normal = False
-
-                if not all_normal:
-                    break
-
-        self.results["success"] = all_normal
+        # Allow dependent workloads time to recover before judging instead of
+        # taking a single snapshot at submit() time (see
+        # MitigationTask.wait_until_pods_healthy).
+        self.results["success"] = self.wait_until_pods_healthy(self.namespace)
         return self.results

--- a/aiopslab/orchestrator/problems/revoke_auth/revoke_auth.py
+++ b/aiopslab/orchestrator/problems/revoke_auth/revoke_auth.py
@@ -165,33 +165,10 @@ class MongoDBRevokeAuthMitigation(MongoDBRevokeAuthBaseTask, MitigationTask):
         print("== Evaluation ==")
         super().eval(soln, trace, duration)
 
-        # Check if all services (not only faulty service) is back to normal (Running)
-        pod_list = self.kubectl.list_pods(self.namespace)
-        all_normal = True
-
-        for pod in pod_list.items:
-            # Check container statuses
-            for container_status in pod.status.container_statuses:
-                if (
-                    container_status.state.waiting
-                    and container_status.state.waiting.reason == "CrashLoopBackOff"
-                ):
-                    print(f"Container {container_status.name} is in CrashLoopBackOff")
-                    all_normal = False
-                elif (
-                    container_status.state.terminated
-                    and container_status.state.terminated.reason != "Completed"
-                ):
-                    print(
-                        f"Container {container_status.name} is terminated with reason: {container_status.state.terminated.reason}"
-                    )
-                    all_normal = False
-                elif not container_status.ready:
-                    print(f"Container {container_status.name} is not ready")
-                    all_normal = False
-
-            if not all_normal:
-                break
-
-        self.results["success"] = all_normal
+        # Allow dependent workloads time to recover before judging. A correct
+        # fix for an app-level fault (e.g. MongoDB auth) often leaves dependent
+        # pods briefly in CrashLoopBackOff, so poll for recovery instead of
+        # taking a single snapshot at submit() time (see
+        # MitigationTask.wait_until_pods_healthy).
+        self.results["success"] = self.wait_until_pods_healthy(self.namespace)
         return self.results

--- a/aiopslab/orchestrator/problems/storage_user_unregistered/storage_user_unregistered.py
+++ b/aiopslab/orchestrator/problems/storage_user_unregistered/storage_user_unregistered.py
@@ -173,33 +173,10 @@ class MongoDBUserUnregisteredMitigation(
         print("== Evaluation ==")
         super().eval(soln, trace, duration)
 
-        # Check if all services (not only faulty service) is back to normal (Running)
-        pod_list = self.kubectl.list_pods(self.namespace)
-        all_normal = True
-
-        for pod in pod_list.items:
-            # Check container statuses
-            for container_status in pod.status.container_statuses:
-                if (
-                    container_status.state.waiting
-                    and container_status.state.waiting.reason == "CrashLoopBackOff"
-                ):
-                    print(f"Container {container_status.name} is in CrashLoopBackOff")
-                    all_normal = False
-                elif (
-                    container_status.state.terminated
-                    and container_status.state.terminated.reason != "Completed"
-                ):
-                    print(
-                        f"Container {container_status.name} is terminated with reason: {container_status.state.terminated.reason}"
-                    )
-                    all_normal = False
-                elif not container_status.ready:
-                    print(f"Container {container_status.name} is not ready")
-                    all_normal = False
-
-            if not all_normal:
-                break
-
-        self.results["success"] = all_normal
+        # Allow dependent workloads time to recover before judging. A correct
+        # fix for an app-level fault (e.g. MongoDB auth) often leaves dependent
+        # pods briefly in CrashLoopBackOff, so poll for recovery instead of
+        # taking a single snapshot at submit() time (see
+        # MitigationTask.wait_until_pods_healthy).
+        self.results["success"] = self.wait_until_pods_healthy(self.namespace)
         return self.results

--- a/aiopslab/orchestrator/tasks/mitigation.py
+++ b/aiopslab/orchestrator/tasks/mitigation.py
@@ -3,7 +3,9 @@
 
 """Define and query information about an AIOps Mitigation task."""
 
+import os
 import textwrap
+import time
 from typing import Any
 
 from aiopslab.orchestrator.tasks.base import Task
@@ -75,3 +77,68 @@ class MitigationTask(Task):
         self.add_result("TTM", duration)
         self.common_eval(trace)
         return self.results
+
+    # ------------------------------------------------------------------
+    # Recovery-health helpers shared by mitigation problems.
+    #
+    # Mitigation eval inspects live pod state. Done as a single snapshot the
+    # instant submit() is called, it penalizes correct fixes whose effect is
+    # not yet visible: app-level faults (e.g. database auth) leave dependent
+    # pods in CrashLoopBackOff, whose exponential back-off (10s, 20s, 40s, ...)
+    # routinely outlasts the moment of submission. Allowing a bounded settle
+    # window makes eval reflect whether the system actually recovered, instead
+    # of whether it happened to be healthy at one instant.
+    # ------------------------------------------------------------------
+    def pods_unhealthy_reasons(self, namespace: str) -> list[str]:
+        """Return human-readable reasons for any unhealthy container in `namespace`.
+
+        An empty list means every container is healthy (no CrashLoopBackOff,
+        no abnormal termination, all ready).
+        """
+        pod_list = self.kubectl.list_pods(namespace)
+        reasons: list[str] = []
+        for pod in pod_list.items:
+            if not pod.status.container_statuses:
+                continue
+            for container_status in pod.status.container_statuses:
+                waiting = container_status.state.waiting
+                terminated = container_status.state.terminated
+                if waiting and waiting.reason == "CrashLoopBackOff":
+                    reasons.append(
+                        f"Container {container_status.name} is in CrashLoopBackOff"
+                    )
+                elif terminated and terminated.reason != "Completed":
+                    reasons.append(
+                        f"Container {container_status.name} is terminated with "
+                        f"reason: {terminated.reason}"
+                    )
+                elif not container_status.ready:
+                    reasons.append(f"Container {container_status.name} is not ready")
+        return reasons
+
+    def wait_until_pods_healthy(
+        self,
+        namespace: str,
+        timeout: float | None = None,
+        poll_interval: float = 5.0,
+    ) -> bool:
+        """Poll until all pods in `namespace` are healthy, or `timeout` elapses.
+
+        Returns True as soon as the namespace is healthy. On timeout, prints the
+        outstanding reasons (preserving the previous eval's diagnostic output)
+        and returns False. The window is configurable via the
+        ``AIOPSLAB_MITIGATION_SETTLE_SECONDS`` env var (default 120s); set it to
+        0 to keep the old single-snapshot behavior.
+        """
+        if timeout is None:
+            timeout = float(os.getenv("AIOPSLAB_MITIGATION_SETTLE_SECONDS", "120"))
+        deadline = time.monotonic() + max(timeout, 0.0)
+        while True:
+            reasons = self.pods_unhealthy_reasons(namespace)
+            if not reasons:
+                return True
+            if time.monotonic() >= deadline:
+                for reason in reasons:
+                    print(reason)
+                return False
+            time.sleep(poll_interval)

--- a/tests/orchestrator/test_mitigation_settle.py
+++ b/tests/orchestrator/test_mitigation_settle.py
@@ -1,0 +1,92 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Tests for the mitigation recovery settle-poll (MitigationTask)."""
+
+import unittest
+from types import SimpleNamespace as NS
+
+from aiopslab.orchestrator.tasks.mitigation import MitigationTask
+
+
+def _container(name, ready=True, waiting=None, terminated=None):
+    state = NS(
+        waiting=NS(reason=waiting) if waiting else None,
+        terminated=NS(reason=terminated) if terminated else None,
+    )
+    return NS(name=name, ready=ready, state=state)
+
+
+def _pod(*containers):
+    return NS(status=NS(container_statuses=list(containers) or None))
+
+
+def _pod_list(*pods):
+    return NS(items=list(pods))
+
+
+class FakeKubeCtl:
+    """Returns a queued sequence of pod-list snapshots (last one repeats)."""
+
+    def __init__(self, snapshots):
+        self.snapshots = snapshots
+        self.calls = 0
+
+    def list_pods(self, namespace):
+        snap = self.snapshots[min(self.calls, len(self.snapshots) - 1)]
+        self.calls += 1
+        return snap
+
+
+def _make_task(snapshots):
+    task = MitigationTask.__new__(MitigationTask)  # bypass Application-dependent __init__
+    task.kubectl = FakeKubeCtl(snapshots)
+    return task
+
+
+class TestMitigationSettle(unittest.TestCase):
+    def test_healthy_namespace_has_no_reasons(self):
+        task = _make_task([_pod_list(_pod(_container("a")), _pod(_container("b")))])
+        self.assertEqual(task.pods_unhealthy_reasons("ns"), [])
+        self.assertTrue(task.wait_until_pods_healthy("ns", timeout=0))
+
+    def test_crashloop_terminated_and_notready_are_flagged(self):
+        task = _make_task(
+            [
+                _pod_list(
+                    _pod(_container("crash", ready=False, waiting="CrashLoopBackOff")),
+                    _pod(_container("term", ready=False, terminated="Error")),
+                    _pod(_container("pending", ready=False)),
+                    _pod(_container("ok")),
+                )
+            ]
+        )
+        reasons = task.pods_unhealthy_reasons("ns")
+        self.assertEqual(len(reasons), 3)
+        self.assertTrue(any("CrashLoopBackOff" in r for r in reasons))
+        self.assertTrue(any("terminated" in r for r in reasons))
+        self.assertTrue(any("not ready" in r for r in reasons))
+
+    def test_completed_container_and_empty_statuses_are_not_abnormal(self):
+        # Preserves the original eval semantics: a "Completed" termination is not
+        # an abnormal termination, and pods without container statuses are skipped.
+        task = _make_task(
+            [_pod_list(_pod(_container("job", ready=True, terminated="Completed")), _pod())]
+        )
+        self.assertEqual(task.pods_unhealthy_reasons("ns"), [])
+
+    def test_waits_until_dependent_pod_recovers(self):
+        # First snapshot crash-looping, second healthy -> polling should succeed.
+        unhealthy = _pod_list(_pod(_container("rate", ready=False, waiting="CrashLoopBackOff")))
+        healthy = _pod_list(_pod(_container("rate")))
+        task = _make_task([unhealthy, healthy])
+        self.assertTrue(task.wait_until_pods_healthy("ns", timeout=10, poll_interval=0))
+        self.assertGreaterEqual(task.kubectl.calls, 2)
+
+    def test_returns_false_when_never_recovers(self):
+        task = _make_task([_pod_list(_pod(_container("rate", ready=False, waiting="CrashLoopBackOff")))])
+        self.assertFalse(task.wait_until_pods_healthy("ns", timeout=0))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Mitigation evaluation currently takes a **single snapshot** of pod health the instant `submit()` is called. This penalizes *correct* fixes whose effect is not yet visible — exactly the case the code's own TODO calls out. This PR adds a bounded settle window so eval reflects whether the system actually recovered, not whether it happened to be healthy at one instant.

## Problem

Each mitigation problem overrides `eval()` with a copy-pasted, single-snapshot readiness loop: it lists pods once and fails if *any* container in the namespace is in `CrashLoopBackOff`, abnormally terminated, or not ready.

This bites app-level faults. `auth_miss_mongodb.py` already flags it:

```python
# TODO: this migigate eval should be a bit different.
# The error will not be on the container/pod level but the app level,
# so the possible mitigation task eval should also check
# whether there are error log appearing.
```

For faults like MongoDB auth (`auth_miss_mongodb`, `revoke_auth`, `storage_user_unregistered`), the injected fault is app/data state, but the *symptom* is a downstream pod (e.g. `rate`, `url-shorten`) that crash-looped because it couldn't reach Mongo at startup. After the agent restores auth, that dependent pod is already in Kubernetes' exponential `CrashLoopBackOff` (10s → 20s → 40s → …), which routinely outlasts the moment of submission — so the single snapshot scores a correct fix as a failure.

## Changes

- Add two reusable helpers to the base `MitigationTask` (`aiopslab/orchestrator/tasks/mitigation.py`):
  - `pods_unhealthy_reasons(namespace)` — the existing container-status check, hoisted and returning human-readable reasons (preserving the old diagnostic prints).
  - `wait_until_pods_healthy(namespace, timeout, poll_interval)` — polls until the namespace is healthy or `timeout` elapses, then prints any outstanding reasons.
- Replace the duplicated single-snapshot loop in the 6 mitigation problems (`auth_miss_mongodb`, `revoke_auth`, `storage_user_unregistered`, `k8s_target_port_misconfig`, `assign_non_existent_node`, `kafka_queue_problems`) with a single call to `self.wait_until_pods_healthy(self.namespace)`.

## Backward compatibility

- Configurable via `AIOPSLAB_MITIGATION_SETTLE_SECONDS` (default **120s**, 5s poll). **Set it to `0` to restore the exact previous single-snapshot behavior.**
- Health semantics are unchanged: "Completed" terminations and pods without container statuses are still treated as healthy/skipped, exactly as before.

## Testing

`tests/orchestrator/test_mitigation_settle.py` — healthy/unhealthy reason detection, "Completed"/empty-status handling, polls until a dependent pod recovers, and times out cleanly when it never does. Passes.

## Notes / follow-ups

This implements the timing half of the TODO (let recovery take time). The app-level **error-log** check the TODO also mentions is left as a follow-up.
