### PR TITLE
Add security benchmark: privileged-pod compromise with Falco + OPA

### DIFF
--- a/aiopslab/generators/fault/inject_security.py
+++ b/aiopslab/generators/fault/inject_security.py
@@ -1,0 +1,170 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Inject security faults: workload compromise scenarios.
+
+Unlike the operational fault injectors, these scenarios do not break the
+application. The app keeps serving traffic; what changes is its *security
+posture* plus a runtime intrusion event. Detecting them therefore requires
+security signals (OPA policy violations, Falco runtime alerts) rather than the
+usual health/latency telemetry -- which is exactly what makes them useful for
+benchmarking a security-capable agent.
+"""
+
+import time
+
+from kubernetes import client
+
+from aiopslab.generators.fault.base import FaultInjector
+from aiopslab.service.kubectl import KubeCtl
+from aiopslab.service.security_tooling import SecurityTooling
+
+HOST_VOLUME_NAME = "host-root"
+
+
+class SecurityFaultInjector(FaultInjector):
+    def __init__(self, namespace: str):
+        self.namespace = namespace
+        self.kubectl = KubeCtl()
+        self.tooling = SecurityTooling()
+        # Maps a hotel-reservation service (deployment) name to its container name.
+        # The HotelReservation manifests name containers `hotel-reserv-<service>`.
+        self.container_name_fmt = "hotel-reserv-{service}"
+
+    ############# FAULT LIBRARY ################
+    # S.1 - priv_escalation: a workload is running privileged with the host
+    #       filesystem mounted, and a runtime intrusion (shell + sensitive-file
+    #       read) is executed inside it. OPA/Gatekeeper flags the misconfig;
+    #       Falco flags the runtime behavior.
+    def inject_priv_escalation(self, microservices: list[str]):
+        """Compromise the given service(s): make privileged + simulate an intrusion."""
+        # Install the security tooling FIRST so Falco is running (and Gatekeeper is
+        # auditing) before the intrusion happens and can therefore capture it.
+        self.tooling.deploy_all(app_namespace=self.namespace)
+
+        for service in microservices:
+            self._make_privileged(service)
+            self._simulate_intrusion(service)
+
+    def recover_priv_escalation(self, microservices: list[str]):
+        """Revert the security posture and remove the tooling."""
+        for service in microservices:
+            self._remove_privileged(service)
+        self.tooling.cleanup()
+
+    # --- internal steps --------------------------------------------------------
+
+    def _make_privileged(self, service: str):
+        """Patch the deployment to run privileged with a hostPath mount of the node root."""
+        deployment = self.kubectl.get_deployment(service, self.namespace)
+        if not deployment:
+            print(f"[WARN] Deployment {service} not found; cannot inject.")
+            return
+
+        container_name = self.container_name_fmt.format(service=service)
+        spec = deployment.spec.template.spec
+
+        for container in spec.containers:
+            if container.name == container_name:
+                container.security_context = client.V1SecurityContext(
+                    privileged=True,
+                    run_as_user=0,
+                    allow_privilege_escalation=True,
+                )
+                mounts = container.volume_mounts or []
+                if not any(m.name == HOST_VOLUME_NAME for m in mounts):
+                    mounts.append(
+                        client.V1VolumeMount(
+                            name=HOST_VOLUME_NAME,
+                            mount_path="/host",
+                            read_only=True,
+                        )
+                    )
+                container.volume_mounts = mounts
+
+        volumes = spec.volumes or []
+        if not any(v.name == HOST_VOLUME_NAME for v in volumes):
+            volumes.append(
+                client.V1Volume(
+                    name=HOST_VOLUME_NAME,
+                    host_path=client.V1HostPathVolumeSource(path="/", type="Directory"),
+                )
+            )
+        spec.volumes = volumes
+
+        self.kubectl.update_deployment(service, self.namespace, deployment)
+        self._wait_rollout(service)
+        print(f"Made {service} privileged with host filesystem mounted.")
+
+    def _simulate_intrusion(self, service: str):
+        """Run suspicious activity inside the compromised pod to trip Falco."""
+        pod = self._get_pod_name(service)
+        if not pod:
+            print(f"[WARN] No running pod for {service}; skipping intrusion step.")
+            return
+
+        container_name = self.container_name_fmt.format(service=service)
+        # Spawning a shell (Falco: "Terminal shell in a container"), reading
+        # /etc/shadow (Falco: "Read sensitive file untrusted"), and touching the
+        # host mount (container-escape reconnaissance). Repeated a couple of times
+        # so the alerts are reliably captured.
+        intrusion = (
+            "sh -c 'id; head -c 128 /etc/shadow; cat /etc/shadow > /dev/null 2>&1; "
+            "ls /host/etc > /dev/null 2>&1'"
+        )
+        for _ in range(3):
+            cmd = (
+                f"kubectl exec {pod} -n {self.namespace} -c {container_name} "
+                f"-- {intrusion}"
+            )
+            result = self.kubectl.exec_command(cmd)
+            print(f"Intrusion step on {pod}: {result.strip()[:200]}")
+            time.sleep(2)
+
+    def _remove_privileged(self, service: str):
+        """Revert the deployment to a compliant, non-privileged posture."""
+        deployment = self.kubectl.get_deployment(service, self.namespace)
+        if not deployment:
+            return
+
+        container_name = self.container_name_fmt.format(service=service)
+        spec = deployment.spec.template.spec
+
+        for container in spec.containers:
+            if container.name == container_name:
+                container.security_context = None
+                if container.volume_mounts:
+                    container.volume_mounts = [
+                        m for m in container.volume_mounts if m.name != HOST_VOLUME_NAME
+                    ]
+
+        if spec.volumes:
+            spec.volumes = [v for v in spec.volumes if v.name != HOST_VOLUME_NAME]
+
+        self.kubectl.update_deployment(service, self.namespace, deployment)
+        self._wait_rollout(service)
+        print(f"Reverted {service} to a non-privileged posture.")
+
+    # --- helpers ---------------------------------------------------------------
+
+    def _get_pod_name(self, service: str) -> str | None:
+        pods = self.kubectl.list_pods(self.namespace)
+        for pod in pods.items:
+            phase = getattr(pod.status, "phase", None)
+            if pod.metadata.name.startswith(service) and phase == "Running":
+                return pod.metadata.name
+        return None
+
+    def _wait_rollout(self, service: str, timeout: str = "120s"):
+        self.kubectl.exec_command(
+            f"kubectl rollout status deployment/{service} "
+            f"-n {self.namespace} --timeout={timeout}"
+        )
+
+
+if __name__ == "__main__":
+    namespace = "test-hotel-reservation"
+    microservices = ["geo"]
+    injector = SecurityFaultInjector(namespace)
+    injector._inject("priv_escalation", microservices)
+    # injector._recover("priv_escalation", microservices)

--- a/aiopslab/orchestrator/problems/registry.py
+++ b/aiopslab/orchestrator/problems/registry.py
@@ -29,6 +29,7 @@ from aiopslab.orchestrator.problems.wrong_bin_usage import *
 from aiopslab.orchestrator.problems.operator_misoperation import *
 from aiopslab.orchestrator.problems.flower_node_stop import *
 from aiopslab.orchestrator.problems.flower_model_misconfig import *
+from aiopslab.orchestrator.problems.security_priv_escalation import *
 
 
 class ProblemRegistry:
@@ -217,6 +218,16 @@ class ProblemRegistry:
             # Flower
             "flower_node_stop-detection": FlowerNodeStopDetection,
             "flower_model_misconfig-detection": FlowerModelMisconfigDetection,
+            # Security: privileged-pod compromise + runtime intrusion (Falco + OPA)
+            "security_priv_escalation_hotel_res-detection-1": lambda: SecurityPrivEscalationDetection(
+                faulty_service="geo"
+            ),
+            "security_priv_escalation_hotel_res-localization-1": lambda: SecurityPrivEscalationLocalization(
+                faulty_service="geo"
+            ),
+            "security_priv_escalation_hotel_res-mitigation-1": lambda: SecurityPrivEscalationMitigation(
+                faulty_service="geo"
+            ),
         }
         self.DOCKER_REGISTRY = [
             "flower_node_stop-detection",

--- a/aiopslab/orchestrator/problems/security_priv_escalation/README.md
+++ b/aiopslab/orchestrator/problems/security_priv_escalation/README.md
@@ -1,0 +1,70 @@
+# Security benchmark: Privileged-pod compromise (Falco + OPA)
+
+A security-oriented AIOpsLab problem for agents that can reason about **both**
+operations and security. It is the canonical Falco/OPA demo turned into a
+benchmark task.
+
+## Scenario
+
+The `geo` workload of **HotelReservation** is patched to run **privileged**
+(`privileged: true`, `runAsUser: 0`) with the **node root filesystem mounted**
+(`hostPath: /`). A short **runtime intrusion** is then executed inside the pod:
+an interactive shell reads `/etc/shadow` and touches the host mount.
+
+The application keeps serving traffic — health, latency, and error telemetry all
+look normal. The incident is only visible through **two independent security
+signals** that the agent must correlate:
+
+| Signal | Tool | How to see it |
+|--------|------|---------------|
+| Privileged container / hostPath mount (static config) | **OPA Gatekeeper** (audit / `dryrun`) | `kubectl get k8spspprivilegedcontainer.constraints.gatekeeper.sh -o yaml` |
+| Shell-in-container + sensitive-file read (runtime) | **Falco** | `kubectl logs -n falco -l app.kubernetes.io/name=falco -c falco` |
+
+Because neither signal alone is conclusive, there is no one-shot answer — the
+agent has to combine a configuration finding with a runtime alert to conclude
+the `geo` workload is compromised.
+
+## Tasks (variants)
+
+| Problem ID | Task | Expected answer / success |
+|------------|------|---------------------------|
+| `security_priv_escalation_hotel_res-detection-1` | Detection | `submit("Yes")` |
+| `security_priv_escalation_hotel_res-localization-1` | Localization | `submit(["geo"])` |
+| `security_priv_escalation_hotel_res-mitigation-1` | Mitigation | remove privileged + hostPath posture **and** keep pods healthy |
+
+The mitigation eval is intentionally stricter than the default "pods are
+Running" check (the compromised pod is Running the whole time): success requires
+`security_posture_fixed AND app_healthy`.
+
+## What the harness deploys automatically
+
+`init_problem()` → deploys HotelReservation → `inject_fault()`:
+
+1. Installs **Falco** (Helm, `falco` ns, `modern_ebpf` driver) and **OPA
+   Gatekeeper** (Helm, `gatekeeper-system` ns) — see
+   [`aiopslab/service/security_tooling.py`](../../../service/security_tooling.py).
+   Gatekeeper constraints are loaded in **audit mode** so the insecure pod is
+   admitted (not blocked).
+2. Patches `geo` to the privileged/host-mounted posture and runs the intrusion —
+   see [`aiopslab/generators/fault/inject_security.py`](../../../generators/fault/inject_security.py).
+
+Falco is installed **before** the intrusion so it captures the runtime event.
+
+## Running it
+
+```bash
+python3 cli.py
+(aiopslab) $ start security_priv_escalation_hotel_res-detection-1
+```
+
+## Requirements / caveats
+
+- The host running AIOpsLab needs `helm` and `kubectl` on PATH with a working
+  kubeconfig (same assumption as the other fault injectors).
+- Falco uses the `modern_ebpf` driver (no kernel headers needed), which works on
+  kind and most modern VMs. On an unusual kernel you may need to switch the
+  driver in `security_tooling.py`.
+- First injection is slow (~minutes) because it `helm install ... --wait`s Falco
+  and Gatekeeper.
+- This is a POC / first canonical security case; the `geo` service is
+  parameterizable if you want to add variants for other workloads.

--- a/aiopslab/orchestrator/problems/security_priv_escalation/__init__.py
+++ b/aiopslab/orchestrator/problems/security_priv_escalation/__init__.py
@@ -1,0 +1,8 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+from .security_priv_escalation import (
+    SecurityPrivEscalationDetection,
+    SecurityPrivEscalationLocalization,
+    SecurityPrivEscalationMitigation,
+)

--- a/aiopslab/orchestrator/problems/security_priv_escalation/helpers.py
+++ b/aiopslab/orchestrator/problems/security_priv_escalation/helpers.py
@@ -1,0 +1,11 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+from aiopslab.service.kubectl import KubeCtl
+from aiopslab.service.apps.base import Application
+
+
+def get_frontend_url(app: Application):
+    kubectl = KubeCtl()
+    endpoint = kubectl.get_cluster_ip(app.frontend_service, app.namespace)
+    return f"http://{endpoint}:{app.frontend_port}"

--- a/aiopslab/orchestrator/problems/security_priv_escalation/security_priv_escalation.py
+++ b/aiopslab/orchestrator/problems/security_priv_escalation/security_priv_escalation.py
@@ -1,0 +1,214 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Privileged-pod compromise security problem in the HotelReservation application.
+
+Scenario (canonical Falco/OPA demo, turned into a benchmark):
+  A workload (`geo`) is running privileged with the node's root filesystem
+  mounted, and a runtime intrusion (interactive shell + reading /etc/shadow) has
+  been executed inside it. The application stays healthy and serves traffic, so
+  ordinary health/latency telemetry looks fine. Two independent security signals
+  reveal the incident:
+    - OPA Gatekeeper (audit)  -> the pod violates the "no privileged container"
+                                 and "no hostPath volume" policies.
+    - Falco (runtime)         -> alerts for shell-in-container and reading a
+                                 sensitive file.
+
+  There is no one-shot answer: the agent must correlate a static
+  misconfiguration with a runtime alert to conclude the workload is compromised.
+"""
+
+from typing import Any
+
+from aiopslab.orchestrator.tasks import *
+from aiopslab.orchestrator.evaluators.quantitative import *
+from aiopslab.service.kubectl import KubeCtl
+from aiopslab.service.apps.hotelres import HotelReservation
+from aiopslab.generators.workload.wrk import Wrk
+from aiopslab.generators.fault.inject_security import (
+    SecurityFaultInjector,
+    HOST_VOLUME_NAME,
+)
+from aiopslab.session import SessionItem
+from aiopslab.paths import TARGET_MICROSERVICES
+
+from .helpers import get_frontend_url
+
+SECURITY_TASK_HINT = """\
+
+    This is a SECURITY investigation. The application may look healthy while
+    still being compromised. Two security tools are deployed in the cluster to
+    help you, in addition to the standard telemetry APIs:
+      - Falco (runtime security) runs as a DaemonSet in the `falco` namespace.
+        Its alerts are emitted to the falco pods' logs, e.g.:
+        `kubectl logs -n falco -l app.kubernetes.io/name=falco -c falco`
+      - OPA Gatekeeper (policy audit) runs in the `gatekeeper-system` namespace.
+        Policy violations on running workloads can be inspected with, e.g.:
+        `kubectl get k8spspprivilegedcontainer.constraints.gatekeeper.sh -o yaml`
+        `kubectl get k8spsphostfilesystem.constraints.gatekeeper.sh -o yaml`
+    Correlate configuration (privilege/host-mount) signals with runtime (Falco)
+    signals to reach your conclusion.
+    """
+
+
+class SecurityPrivEscalationBaseTask:
+    def __init__(self, faulty_service: str = "geo"):
+        self.app = HotelReservation()
+        self.kubectl = KubeCtl()
+        self.namespace = self.app.namespace
+        self.faulty_service = faulty_service
+        self.payload_script = (
+            TARGET_MICROSERVICES
+            / "hotelReservation/wrk2/scripts/hotel-reservation/mixed-workload_type_1.lua"
+        )
+
+    def start_workload(self):
+        print("== Start Workload ==")
+        frontend_url = get_frontend_url(self.app)
+
+        wrk = Wrk(rate=10, dist="exp", connections=2, duration=10, threads=2)
+        wrk.start_workload(
+            payload_script=self.payload_script,
+            url=f"{frontend_url}",
+        )
+
+    def inject_fault(self):
+        print("== Fault Injection ==")
+        injector = SecurityFaultInjector(namespace=self.namespace)
+        injector._inject(
+            fault_type="priv_escalation",
+            microservices=[self.faulty_service],
+        )
+        print(f"Service: {self.faulty_service} | Namespace: {self.namespace}\n")
+
+    def recover_fault(self):
+        print("== Fault Recovery ==")
+        injector = SecurityFaultInjector(namespace=self.namespace)
+        injector._recover(
+            fault_type="priv_escalation",
+            microservices=[self.faulty_service],
+        )
+        print(f"Service: {self.faulty_service} | Namespace: {self.namespace}\n")
+
+    # --- shared security-state check ------------------------------------------
+    def is_compromised(self) -> bool:
+        """True if the faulty service still runs privileged or mounts the host FS."""
+        deployment = self.kubectl.get_deployment(self.faulty_service, self.namespace)
+        if not deployment:
+            return False
+
+        spec = deployment.spec.template.spec
+        for container in spec.containers:
+            sc = container.security_context
+            if sc and (sc.privileged or sc.run_as_user == 0):
+                return True
+
+        for volume in spec.volumes or []:
+            if volume.host_path is not None or volume.name == HOST_VOLUME_NAME:
+                return True
+
+        return False
+
+
+################## Detection Problem ##################
+class SecurityPrivEscalationDetection(
+    SecurityPrivEscalationBaseTask, DetectionTask
+):
+    def __init__(self, faulty_service: str = "geo"):
+        SecurityPrivEscalationBaseTask.__init__(self, faulty_service=faulty_service)
+        DetectionTask.__init__(self, self.app)
+        self.task_desc += SECURITY_TASK_HINT
+
+    def eval(self, soln: Any, trace: list[SessionItem], duration: float):
+        print("== Evaluation ==")
+        expected_solution = "Yes"
+
+        if isinstance(soln, str):
+            if soln.strip().lower() == expected_solution.lower():
+                print(f"Correct detection: {soln}")
+                self.add_result("Detection Accuracy", "Correct")
+            else:
+                print(f"Incorrect detection: {soln}")
+                self.add_result("Detection Accuracy", "Incorrect")
+        else:
+            print("Invalid solution format")
+            self.add_result("Detection Accuracy", "Invalid Format")
+
+        return super().eval(soln, trace, duration)
+
+
+################## Localization Problem ##################
+class SecurityPrivEscalationLocalization(
+    SecurityPrivEscalationBaseTask, LocalizationTask
+):
+    def __init__(self, faulty_service: str = "geo"):
+        SecurityPrivEscalationBaseTask.__init__(self, faulty_service=faulty_service)
+        LocalizationTask.__init__(self, self.app)
+        self.task_desc += SECURITY_TASK_HINT
+
+    def eval(self, soln: Any, trace: list[SessionItem], duration: float):
+        print("== Evaluation ==")
+
+        if soln is None:
+            print("Solution is None")
+            self.add_result("Localization Accuracy", 0.0)
+            self.results["success"] = False
+            self.results["is_subset"] = False
+            super().eval(soln, trace, duration)
+            return self.results
+
+        is_exact = is_exact_match(soln, self.faulty_service)
+        is_sub = is_subset([self.faulty_service], soln)
+
+        if is_exact:
+            accuracy = 100.0
+            print(f"Exact match: {soln} | Accuracy: {accuracy}%")
+        elif is_sub:
+            accuracy = (len([self.faulty_service]) / len(soln)) * 100.0
+            print(f"Subset match: {soln} | Accuracy: {accuracy:.2f}%")
+        else:
+            accuracy = 0.0
+            print(f"No match: {soln} | Accuracy: {accuracy}%")
+
+        self.add_result("Localization Accuracy", accuracy)
+        super().eval(soln, trace, duration)
+
+        self.results["success"] = is_exact or (is_sub and len(soln) == 1)
+        self.results["is_subset"] = is_sub
+
+        return self.results
+
+
+################## Mitigation Problem ##################
+class SecurityPrivEscalationMitigation(
+    SecurityPrivEscalationBaseTask, MitigationTask
+):
+    def __init__(self, faulty_service: str = "geo"):
+        SecurityPrivEscalationBaseTask.__init__(self, faulty_service=faulty_service)
+        MitigationTask.__init__(self, self.app)
+        self.task_desc += SECURITY_TASK_HINT
+
+    def eval(self, soln: Any, trace: list[SessionItem], duration: float) -> dict:
+        print("== Evaluation ==")
+        super().eval(soln, trace, duration)
+
+        # A correct mitigation must (a) remove the insecure posture (no longer
+        # privileged / no host mount) AND (b) keep the app healthy. Note this is
+        # deliberately stricter than the usual "pods are Running" check, since the
+        # compromised pod was Running the whole time.
+        still_compromised = self.is_compromised()
+        if still_compromised:
+            print(f"{self.faulty_service} is still running with an insecure posture.")
+
+        try:
+            self.kubectl.wait_for_ready(self.namespace, sleep=5, max_wait=60)
+            healthy = True
+        except Exception as e:
+            print(f"Pods are not all ready: {e}")
+            healthy = False
+
+        self.results["security_posture_fixed"] = not still_compromised
+        self.results["app_healthy"] = healthy
+        self.results["success"] = (not still_compromised) and healthy
+
+        return self.results

--- a/aiopslab/service/security_tooling.py
+++ b/aiopslab/service/security_tooling.py
@@ -1,0 +1,220 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+"""Install and manage in-cluster security tooling: Falco + OPA Gatekeeper.
+
+Security-oriented benchmark problems install this tooling so that a
+security-capable agent's arsenal has live data to query:
+
+  - Falco       -> runtime (syscall/eBPF) detection. Emits alerts to the
+                   stdout of the falco pods, readable via `kubectl logs`.
+  - Gatekeeper  -> admission/audit policy detection (OPA). Records policy
+                   violations on the running workloads.
+
+The Gatekeeper constraints are installed in *audit* mode
+(`enforcementAction: dryrun`) on purpose: an insecure workload must still be
+admitted and stay healthy so that the agent has to actively discover it,
+rather than having the platform block the deployment outright.
+
+NOTE: This helper shells out to `helm` and `kubectl` on the machine running
+AIOpsLab (the same way the other fault injectors do). The host must therefore
+have `helm` and `kubectl` on its PATH and a working kubeconfig.
+"""
+
+import time
+
+from aiopslab.service.kubectl import KubeCtl
+
+FALCO_NAMESPACE = "falco"
+GATEKEEPER_NAMESPACE = "gatekeeper-system"
+
+FALCO_REPO_NAME = "falcosecurity"
+FALCO_REPO_URL = "https://falcosecurity.github.io/charts"
+GATEKEEPER_REPO_NAME = "gatekeeper"
+GATEKEEPER_REPO_URL = "https://open-policy-agent.github.io/gatekeeper/charts"
+
+# --- Gatekeeper policy assets --------------------------------------------------
+
+# ConstraintTemplate: forbid privileged containers.
+PRIVILEGED_TEMPLATE = """
+apiVersion: templates.gatekeeper.sh/v1
+kind: ConstraintTemplate
+metadata:
+  name: k8spspprivilegedcontainer
+spec:
+  crd:
+    spec:
+      names:
+        kind: K8sPSPPrivilegedContainer
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      rego: |
+        package k8spspprivileged
+        violation[{"msg": msg}] {
+          c := input_containers[_]
+          c.securityContext.privileged
+          msg := sprintf("Privileged container is not allowed: %v", [c.name])
+        }
+        input_containers[c] {
+          c := input.review.object.spec.containers[_]
+        }
+        input_containers[c] {
+          c := input.review.object.spec.initContainers[_]
+        }
+"""
+
+# ConstraintTemplate: forbid hostPath volumes.
+HOSTPATH_TEMPLATE = """
+apiVersion: templates.gatekeeper.sh/v1
+kind: ConstraintTemplate
+metadata:
+  name: k8spsphostfilesystem
+spec:
+  crd:
+    spec:
+      names:
+        kind: K8sPSPHostFilesystem
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      rego: |
+        package k8spsphostfilesystem
+        violation[{"msg": msg}] {
+          volume := input.review.object.spec.volumes[_]
+          volume.hostPath
+          msg := sprintf("HostPath volume is not allowed: %v", [volume.name])
+        }
+"""
+
+# Constraints are rendered per-namespace and applied in dryrun (audit) mode.
+PRIVILEGED_CONSTRAINT = """
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: K8sPSPPrivilegedContainer
+metadata:
+  name: psp-privileged-container
+spec:
+  enforcementAction: dryrun
+  match:
+    kinds:
+      - apiGroups: [""]
+        kinds: ["Pod"]
+    namespaces: ["{namespace}"]
+"""
+
+HOSTPATH_CONSTRAINT = """
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: K8sPSPHostFilesystem
+metadata:
+  name: psp-host-filesystem
+spec:
+  enforcementAction: dryrun
+  match:
+    kinds:
+      - apiGroups: [""]
+        kinds: ["Pod"]
+    namespaces: ["{namespace}"]
+"""
+
+
+class SecurityTooling:
+    """Deploy/tear down Falco and OPA Gatekeeper for security benchmarks."""
+
+    def __init__(self):
+        self.kubectl = KubeCtl()
+
+    # --- public API ------------------------------------------------------------
+
+    def deploy_all(self, app_namespace: str):
+        """Install Falco and Gatekeeper and load audit policies for `app_namespace`."""
+        self.deploy_falco()
+        self.deploy_gatekeeper()
+        self.load_policies(app_namespace)
+
+    def cleanup(self):
+        """Best-effort removal of the security tooling and its policies."""
+        print("== Security Tooling Cleanup ==")
+        self._apply_yaml(PRIVILEGED_CONSTRAINT.format(namespace="_"), delete=True)
+        self._apply_yaml(HOSTPATH_CONSTRAINT.format(namespace="_"), delete=True)
+        self._apply_yaml(PRIVILEGED_TEMPLATE, delete=True)
+        self._apply_yaml(HOSTPATH_TEMPLATE, delete=True)
+        self._run(f"helm uninstall gatekeeper -n {GATEKEEPER_NAMESPACE}")
+        self._run(f"helm uninstall falco -n {FALCO_NAMESPACE}")
+
+    # --- Falco -----------------------------------------------------------------
+
+    def deploy_falco(self):
+        print("== Deploying Falco ==")
+        if self._helm_release_exists("falco", FALCO_NAMESPACE):
+            print("Falco already installed. Skipping.")
+            return
+        self._add_repo(FALCO_REPO_NAME, FALCO_REPO_URL)
+        # modern_ebpf needs no kernel headers, so it works on kind and most VMs.
+        # json_output makes the alerts easy to parse; falcosidekick is unneeded
+        # because the agent reads alerts straight from the pod logs.
+        cmd = (
+            f"helm upgrade --install falco {FALCO_REPO_NAME}/falco "
+            f"--namespace {FALCO_NAMESPACE} --create-namespace "
+            "--set tty=true "
+            "--set driver.kind=modern_ebpf "
+            "--set collectors.kubernetes.enabled=true "
+            "--set falcosidekick.enabled=false "
+            "--set falco.json_output=true "
+            "--wait --timeout 6m"
+        )
+        print(self._run(cmd))
+
+    # --- Gatekeeper ------------------------------------------------------------
+
+    def deploy_gatekeeper(self):
+        print("== Deploying OPA Gatekeeper ==")
+        if not self._helm_release_exists("gatekeeper", GATEKEEPER_NAMESPACE):
+            self._add_repo(GATEKEEPER_REPO_NAME, GATEKEEPER_REPO_URL)
+            cmd = (
+                f"helm upgrade --install gatekeeper {GATEKEEPER_REPO_NAME}/gatekeeper "
+                f"--namespace {GATEKEEPER_NAMESPACE} --create-namespace "
+                "--set replicas=1 "
+                "--set audit.interval=30 "
+                "--wait --timeout 6m"
+            )
+            print(self._run(cmd))
+        else:
+            print("Gatekeeper already installed. Skipping.")
+
+    def load_policies(self, app_namespace: str):
+        """Apply constraint templates + (dryrun) constraints scoped to a namespace."""
+        print("== Loading Gatekeeper audit policies ==")
+        self._apply_yaml(PRIVILEGED_TEMPLATE)
+        self._apply_yaml(HOSTPATH_TEMPLATE)
+
+        # The constraint CRDs only exist once Gatekeeper reconciles the templates.
+        self._wait_for_crd("k8spspprivilegedcontainer.constraints.gatekeeper.sh")
+        self._wait_for_crd("k8spsphostfilesystem.constraints.gatekeeper.sh")
+
+        self._apply_yaml(PRIVILEGED_CONSTRAINT.format(namespace=app_namespace))
+        self._apply_yaml(HOSTPATH_CONSTRAINT.format(namespace=app_namespace))
+
+    # --- helpers ---------------------------------------------------------------
+
+    def _run(self, command: str) -> str:
+        return self.kubectl.exec_command(command)
+
+    def _add_repo(self, name: str, url: str):
+        self._run(f"helm repo add {name} {url}")
+        self._run("helm repo update")
+
+    def _helm_release_exists(self, release: str, namespace: str) -> bool:
+        out = self._run(f"helm status {release} -n {namespace}")
+        return "STATUS: deployed" in out
+
+    def _apply_yaml(self, manifest: str, delete: bool = False):
+        verb = "delete --ignore-not-found" if delete else "apply"
+        return self.kubectl.exec_command(f"kubectl {verb} -f -", input_data=manifest)
+
+    def _wait_for_crd(self, crd_name: str, max_wait: int = 90, sleep: int = 3):
+        waited = 0
+        while waited < max_wait:
+            out = self._run(f"kubectl get crd {crd_name} --no-headers")
+            if crd_name in out:
+                return
+            time.sleep(sleep)
+            waited += sleep
+        print(f"[WARN] Timed out waiting for CRD {crd_name} to be established.")


### PR DESCRIPTION
Adds a security-oriented AIOpsLab problem (Detection/Localization/Mitigation) based on HotelReservation. The geo workload is made privileged with the node root filesystem mounted, and a runtime intrusion (shell + /etc/shadow read) is executed inside it. The app stays healthy, so detection requires correlating an OPA Gatekeeper policy violation (static) with a Falco runtime alert.

The harness auto-installs Falco and OPA Gatekeeper (audit mode) into the cluster during fault injection.